### PR TITLE
Update background color of Left Menu components (both DragDropPanel and MUIDragDropPanel) to make consistent with background color of entire Left Menu

### DIFF
--- a/app/src/components/left/DragDropPanel.tsx
+++ b/app/src/components/left/DragDropPanel.tsx
@@ -19,7 +19,7 @@ const useStyles = makeStyles({
     color: '#ffffff' // Set the text color to white
   },
   accordionSummary: {
-    backgroundColor: '#101012', // Set the background color of the summary to gray
+    backgroundColor: '#1E2024', // Set the background color of the summary to gray
     color: '#ffffff' // Set the text color of the summary to white
   }
 });

--- a/app/src/components/left/MUIDragDropPanel.tsx
+++ b/app/src/components/left/MUIDragDropPanel.tsx
@@ -19,7 +19,7 @@ const useStyles = makeStyles({
     color: '#ffffff' // Set the text color to white
   },
   accordionSummary: {
-    backgroundColor: '#101012', // Set the background color of the summary to gray
+    backgroundColor: '#1E2024', // Set the background color of the summary to gray
     color: '#ffffff' // Set the text color of the summary to white
   }
 });


### PR DESCRIPTION
# Description

Please describe the issue of the pull request and the changes

- Update background color of Left Menu components (both DragDropPanel and MUIDragDropPanel) to make consistent with background color of entire Left Menu

## Type of Change

Please check the options that apply

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has the Changes Been Tested?

- Visually tested through GUI and user experience.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] Changes included in this pull request covers minimal topic
- [x] I have performed a self-review of my code
- [x] I have commented my code properly, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

![image](https://github.com/user-attachments/assets/7c2179b6-4d8d-4af3-a5dc-c1473128ab30)
![image](https://github.com/user-attachments/assets/258eadf0-4ca9-40fe-99ef-a926b6f1ddef)